### PR TITLE
fix stop iner problem

### DIFF
--- a/deeponetx/data/data.py
+++ b/deeponetx/data/data.py
@@ -47,4 +47,4 @@ class DatasetDeepONet(data.Dataset):
         """Sample data
         """
         index = jr.choice(key, self.input_branch.shape[0], (self.batch_size,), replace=False)
-        return DataDeepONet(self.input_branch[index, :], self.input_trunk[index, :], self.output[index, :])
+        return DataDeepONet(self.input_branch[index], self.input_trunk[index], self.output[index])


### PR DESCRIPTION
```
{
	"name": "StopIteration",
	"message": "",
	"stack": "---------------------------------------------------------------------------
StopIteration                             Traceback (most recent call last)
File /home/stevenchiu/Documents/github/deeponetx/examples/antiderivative_1d.py:116
    113 net = dtx.nn.create_UnstackDeepONet1d_MLP(in_size_branch, width_size, depth, interact_size, activation, key=key)
    115 # Training
--> 116 net, losses = traindtx.train(net, data_train, optimizer, 10000)

File ~/Documents/github/deeponetx/deeponetx/train.py:39, in train(model, dataloader, optimizer, n_iter)
     37 with tqdm(range(n_iter)) as t:
     38     for i in t:
---> 39         batch = next(data_iter)
     40         model, state, loss = update_fn(model, batch, optimizer, state)
     41         losses[i] = loss

StopIteration: "
}
```